### PR TITLE
Code quality fix - Null pointers should not be dereferenced.

### DIFF
--- a/src/main/java/org/complykit/licensecheck/mojo/OpenSourceLicenseCheckMojo.java
+++ b/src/main/java/org/complykit/licensecheck/mojo/OpenSourceLicenseCheckMojo.java
@@ -444,7 +444,9 @@ public class OpenSourceLicenseCheckMojo extends AbstractMojo
       getLog().error(e);
     } finally {
       try {
-        reader.close();
+        if ( reader != null){
+        	reader.close();
+        }
       } catch (final IOException e) {
         // TODO
         e.printStackTrace();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2259- Null pointers should not be dereferenced.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2259

Please let me know if you have any questions.

Faisal Hameed

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mrice/license-check/21)

<!-- Reviewable:end -->
