### PR TITLE
Code quality fix - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.

### DIFF
--- a/src/main/java/org/complykit/licensecheck/mojo/OpenSourceLicenseCheckMojo.java
+++ b/src/main/java/org/complykit/licensecheck/mojo/OpenSourceLicenseCheckMojo.java
@@ -308,7 +308,7 @@ public class OpenSourceLicenseCheckMojo extends AbstractMojo
   String readPomContents(final String path) throws IOException
   {
 
-    final StringBuffer buffer = new StringBuffer();
+    final StringBuilder buffer = new StringBuilder();
     BufferedReader reader = null;
 
     reader = new BufferedReader(new FileReader(path));
@@ -433,7 +433,7 @@ public class OpenSourceLicenseCheckMojo extends AbstractMojo
     final InputStream is = getClass().getResourceAsStream(licensesPath);
     BufferedReader reader = null;
     descriptors = new ArrayList<LicenseDescriptor>();
-    final StringBuffer buffer = new StringBuffer();
+    final StringBuilder buffer = new StringBuilder();
     try {
       reader = new BufferedReader(new InputStreamReader(is));
       String line = null;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149

Please let me know if you have any questions.

Faisal Hameed

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mrice/license-check/22)

<!-- Reviewable:end -->
