### PR TITLE
Multiple code quality fix-1

### DIFF
--- a/src/main/java/org/complykit/licensecheck/mojo/OpenSourceLicenseCheckMojo.java
+++ b/src/main/java/org/complykit/licensecheck/mojo/OpenSourceLicenseCheckMojo.java
@@ -340,8 +340,7 @@ public class OpenSourceLicenseCheckMojo extends AbstractMojo
     final String nameTagStart = "<name>", nameTagStop = "</name>";
     if (raw.indexOf(licenseTagStart) != -1) {
       final String licenseContents = raw.substring(raw.indexOf(licenseTagStart) + licenseTagStart.length(), raw.indexOf(licenseTagStop));
-      final String name = licenseContents.substring(licenseContents.indexOf(nameTagStart) + nameTagStart.length(), licenseContents.indexOf(nameTagStop));
-      return name;
+      return licenseContents.substring(licenseContents.indexOf(nameTagStart) + nameTagStart.length(), licenseContents.indexOf(nameTagStop));
     }
     return null;
   }
@@ -451,9 +450,9 @@ public class OpenSourceLicenseCheckMojo extends AbstractMojo
       }
     }
 
-    final String lines[] = buffer.toString().split("\n");
+    final String[] lines = buffer.toString().split("\n");
     for (final String line : lines) {
-      final String columns[] = line.split("\\t");
+      final String[] columns = line.split("\\t");
       final LicenseDescriptor descriptor = new LicenseDescriptor();
       descriptor.setCode(columns[0]);
       descriptor.setLicenseName(columns[2]);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown. 
squid:S1197 - Array designators "[]" should be on the type, not the variable.
You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1488
https://dev.eclipse.org/sonar/rules/show/squid:S1197

Please let me know if you have any questions.

Faisal Hameed

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mrice/license-check/23)

<!-- Reviewable:end -->
