### PR TITLE
Multiple code quality fix-2

### DIFF
--- a/src/main/java/org/complykit/licensecheck/mojo/OpenSourceLicenseCheckMojo.java
+++ b/src/main/java/org/complykit/licensecheck/mojo/OpenSourceLicenseCheckMojo.java
@@ -151,7 +151,7 @@ public class OpenSourceLicenseCheckMojo extends AbstractMojo
   /**
    * Used to hold the list of license descriptors. Generation is lazy on the first method call to use it.
    */
-  List<LicenseDescriptor> descriptors = null;
+  List<LicenseDescriptor> descriptors;
 
   public void execute() throws MojoExecutionException, MojoFailureException
   {
@@ -194,14 +194,14 @@ public class OpenSourceLicenseCheckMojo extends AbstractMojo
         }
         String code = convertLicenseNameToCode(licenseName);
         if (code == null) {
-          if (excludeNoLicense==false) {
+          if (!excludeNoLicense) {
             buildFails = true;
             getLog().warn("Build will fail because of artifact '" + toCoordinates(artifact) + "' and license'" + licenseName + "'.");
           }
-        } else if (blacklistSet.isEmpty() == false && isContained(blacklistSet, code)) {
+        } else if (!blacklistSet.isEmpty() && isContained(blacklistSet, code)) {
           buildFails = true;
           code += " IS ON YOUR BLACKLIST";
-        } else if (whitelistSet.isEmpty() == false && isContained(whitelistSet, code) == false) {
+        } else if (!whitelistSet.isEmpty() && !isContained(whitelistSet, code)) {
           buildFails = true;
           code += " IS NOT ON YOUR WHITELIST";
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
pmd:RedundantFieldInitializer - Redundant Field Initializer. 
squid:S1125 - Literal boolean values should not be used in condition expressions. 
You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/pmd:RedundantFieldInitializer
https://dev.eclipse.org/sonar/rules/show/squid:S1125

Please let me know if you have any questions.

Faisal Hameed

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mrice/license-check/24)

<!-- Reviewable:end -->
